### PR TITLE
Fix typos in gas benchmark section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We use `forge fmt` to format. But follow a few general guidelines beyond the sta
 
 You can run `./bootstrap.sh gas_report` to generate a detailed gas report for the current state and update the gas_report.md file.
 
-If you want something more manageble you should be using the `./boostrap.sh gas_benchmark` which will give you some "happy path" gas numbers for set with and without validators in a format that might be slightly simpler to figure out. The values outputted from this can also be seen over time at https://aztecprotocol.github.io/aztec-packages/dev/l1-gas-bench/.
+If you want something more manageable you should be using the `./bootstrap.sh gas_benchmark` which will give you some "happy path" gas numbers for set with and without validators in a format that might be slightly simpler to figure out. The values outputted from this can also be seen over time at https://aztecprotocol.github.io/aztec-packages/dev/l1-gas-bench/.
 
 When running CI or tests with `./bootstrap.sh test`, the script will automatically check if gas usage has changed by running `./bootstrap.sh gas_report check`. If gas usage has changed, the test will fail and show a diff of the changes.
 


### PR DESCRIPTION
Corrected script name from `./boostrap.sh` → `./bootstrap.sh`

Fixed typo `manageble` → `manageable`