### PR TITLE
quick untested fix to make the npm package work with hardhat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ gas_benchmark.diff
 /bench-out
 
 /coverage
+
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# WARNING this is a unofficial hacky fix
-install: `yarn add aztec-l1-contracts-hardhat-fix`
-
 # L1 Contracts
 
 This directory contains the Ethereum smart contracts for progressing the state of the Rollup.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# WARNING this is a unofficial hacky fix
+install: `yarn add aztec-l1-contracts-hardhat-fix`
+
 # L1 Contracts
 
 This directory contains the Ethereum smart contracts for progressing the state of the Rollup.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "aztec-l1-contracts-hardhat-fix",
-  "version": "2.0.6",
+  "name": "@aztec/l1-contracts",
+  "version": "2.0.3",
   "license": "Apache-2.0",
   "description": "Aztec contracts for the Ethereum mainnet and testnets",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
-  "name": "@aztec/l1-contracts",
-  "version": "2.0.3",
+  "name": "aztec-l1-contracts-hardhat-fix",
+  "version": "2.0.6",
   "license": "Apache-2.0",
   "description": "Aztec contracts for the Ethereum mainnet and testnets",
   "devDependencies": {
-    "@openzeppelin/merkle-tree": "^1.0.8",
     "ox": "^0.8.3",
     "solhint": "5.1.0"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "5.4.0",
+    "@openzeppelin/merkle-tree": "^1.0.8",
+    "forge-std": "git+https://github.com/foundry-rs/forge-std.git"
   },
   "scripts": {
     "format": "forge fmt",
@@ -15,8 +19,5 @@
     "slither": "forge clean && forge build --build-info --skip '*/test/**' --force && slither . --checklist --ignore-compile --show-ignored-findings --config-file ./slither.config.json | tee slither_output.md",
     "slither-has-diff": "./slither_has_diff.sh"
   },
-  "packageManager": "yarn@4.5.2",
-  "dependencies": {
-    "@openzeppelin/contracts": "^5.4.0"
-  }
+  "packageManager": "yarn@4.5.2"
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "slither": "forge clean && forge build --build-info --skip '*/test/**' --force && slither . --checklist --ignore-compile --show-ignored-findings --config-file ./slither.config.json | tee slither_output.md",
     "slither-has-diff": "./slither_has_diff.sh"
   },
-  "packageManager": "yarn@4.5.2"
+  "packageManager": "yarn@4.5.2",
+  "dependencies": {
+    "@openzeppelin/contracts": "^5.4.0"
+  }
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,3 @@
+@oz/=node_modules/@openzeppelin/contracts
+@aztec/=src
+@test/=test

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,4 @@
 @oz/=node_modules/@openzeppelin/contracts
+forge-std/=node_modules/forge-std/src/
 @aztec/=src
 @test/=test


### PR DESCRIPTION
Closes: #3 
I couldn't figure out how to use the tests here so not sure if it is merge-able.
But i was able to publish it to npm [here](https://www.npmjs.com/package/aztec-l1-contracts-hardhat-fix) (the version is off but it's for aztec 2.0.3), and use it in my own hardhat repo [here](https://github.com/warptoad/giga-bridge/tree/28fa8ececeb57d18bceab4c99c2bd9eac09c3d13/packages/giga-bridge-contracts)!